### PR TITLE
added filetype detection for .🔥 files

### DIFF
--- a/ftdetect/mojo.vim
+++ b/ftdetect/mojo.vim
@@ -1,4 +1,4 @@
-autocmd BufRead,BufNewFile *.mojo call s:set_mojo_filetype()
+autocmd BufRead,BufNewFile *.mojo,*.🔥 call s:set_mojo_filetype()
 
 function! s:set_mojo_filetype() abort
     if &filetype !=# 'mojo'


### PR DESCRIPTION
.🔥 is an officially supported file extension for mojo files, so it should be included in the filetype detection